### PR TITLE
Adjust Commit Message Check to Work with Multi-line Commits

### DIFF
--- a/check_commit_msgs.sh
+++ b/check_commit_msgs.sh
@@ -56,7 +56,7 @@ then
   for commit_hash in ${rev_list}
   do
     # read the commit message and store it in a temporary file
-    git rev-list --format=%B --max-count=1 ${commit_hash} | tail --lines=2 > .tmp_commit_msg_storage
+    git log --format=%B --max-count=1 ${commit_hash} > .tmp_commit_msg_storage
     echo "Now analyzing commit message of ${commit_hash}:"
     echo "-----------"
     cat .tmp_commit_msg_storage

--- a/{{cookiecutter.repo_name}}/check_commit_msgs.sh
+++ b/{{cookiecutter.repo_name}}/check_commit_msgs.sh
@@ -56,7 +56,7 @@ then
   for commit_hash in ${rev_list}
   do
     # read the commit message and store it in a temporary file
-    git rev-list --format=%B --max-count=1 ${commit_hash} | tail --lines=2 > .tmp_commit_msg_storage
+    git log --format=%B --max-count=1 ${commit_hash} > .tmp_commit_msg_storage
     echo "Now analyzing commit message of ${commit_hash}:"
     echo "-----------"
     cat .tmp_commit_msg_storage


### PR DESCRIPTION
The previous check relied on the tail command in order to strip the first line of git rev-list containing the commit hash. However, the command worked only for single line commit messages. git log gives essentially the same output, so use it instead.