### PR TITLE
Use the Correct Git Reference in Pull Requests

### DIFF
--- a/.github/workflows/format_and_lint.yaml
+++ b/.github/workflows/format_and_lint.yaml
@@ -35,6 +35,4 @@ jobs:
                   pre-commit install
                   pre-commit run --hook-stage manual --all-files
                   git fetch
-                  export branch_name=${{ github.ref_name }}
-                  if [[ ${{ github.event_name }} == "pull_request" ]]; then export branch_name=${{ github.head_ref}}; fi
-                  ./check_commit_msgs.sh -c "remotes/origin/${branch_name}" -m "remotes/origin/${{ github.event.repository.default_branch }}"
+                  ./check_commit_msgs.sh -c HEAD -m "remotes/origin/${{ github.event.repository.default_branch }}"


### PR DESCRIPTION
Apparently, GitHub Actions has different Git references when running on pull requests from other repositories. This PR will use ~~the variable provided by GitHub itself~~ HEAD instead. This will include the additional merge commit that GitHub creates. This should however pass the commit message check, so the effect should be the same.