### PR TITLE
chore: added system files to gitignore

### DIFF
--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -80,6 +80,15 @@ venv.bak/
 .idea
 .vscode
 
+# System files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
 # Data
 data/*
 !data/raw/


### PR DESCRIPTION
Added assortment of files to .gitignore that are automatically generated by OS. List of files taken from [this gist](https://gist.github.com/octocat/9257657#file-gitignore-L29).