### PR TITLE
Bump commitlint to 9.11.0 and make check script work

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,10 +23,11 @@ repos:
                 - manual
           - id: requirements-txt-fixer
     - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-      rev: v9.5.0
+      rev: v9.11.0
       hooks:
           - id: commitlint
             additional_dependencies: ['@commitlint/config-conventional']
+            pass_filenames: true
             stages:
                 - commit-msg
     - repo: https://github.com/pycqa/isort

--- a/check_commit_msgs.sh
+++ b/check_commit_msgs.sh
@@ -44,13 +44,6 @@ echo "Getting new commits from ${commit_branch} w.r.t. ${main_branch}"
 merge_base=$(git merge-base ${commit_branch} ${main_branch})
 rev_list=$(git rev-list --ancestry-path ${merge_base}..${commit_branch})
 
-# check if .git.COMMIT_EDITMSG exists, create dummy file otherwise
-# pre-commit commitlint will fail if file does not exist
-# this happens on a fresh clone of the repo
-if [ ! -f ./.git/COMMIT_EDITMSG ]; then
-  touch ./.git/COMMIT_EDITMSG
-fi
-
 # check commit messages
 if [ -n "${rev_list}" ]
 then

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -25,10 +25,11 @@ repos:
                 - manual
           - id: requirements-txt-fixer
     - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-      rev: v9.5.0
+      rev: v9.11.0
       hooks:
           - id: commitlint
             additional_dependencies: ['@commitlint/config-conventional']
+            pass_filenames: true
             stages:
                 - commit-msg
     - repo: https://github.com/pycqa/isort

--- a/{{cookiecutter.repo_name}}/check_commit_msgs.sh
+++ b/{{cookiecutter.repo_name}}/check_commit_msgs.sh
@@ -44,13 +44,6 @@ echo "Getting new commits from ${commit_branch} w.r.t. ${main_branch}"
 merge_base=$(git merge-base ${commit_branch} ${main_branch})
 rev_list=$(git rev-list --ancestry-path ${merge_base}..${commit_branch})
 
-# check if .git.COMMIT_EDITMSG exists, create dummy file otherwise
-# pre-commit commitlint will fail if file does not exist
-# this happens on a fresh clone of the repo
-if [ ! -f ./.git/COMMIT_EDITMSG ]; then
-  touch ./.git/COMMIT_EDITMSG
-fi
-
 # check commit messages
 if [ -n "${rev_list}" ]
 then


### PR DESCRIPTION
The script to check commit messages was voided, as filenames were no longer passed. This change was hidden by touching COMMIT_EDITMSG before running the script. This reverts the change to the script and enables the passthrough of filenames.

Fixes #29 