### PR TITLE
Allow Testing Templates with Different Configurations + Additional Tests

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -27,7 +27,7 @@ class CondaLikePackageManager(ABC):
 
     def remove_env(self, env_name: str):
         full_cmd = [self.executable, "env", "remove", "--name", env_name]
-        subprocess.run(full_cmd, check=True)
+        subprocess.run(full_cmd, check=True, env={"CONDA_YES": "true"})
 
 
 class CondaPackageManager(CondaLikePackageManager):

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name
 # standard library imports
+import os
 import pathlib
 import uuid
 
@@ -14,24 +15,28 @@ TEMPLATE_DIRECTORY = str(pathlib.Path(__file__).parent.parent)
 PACKAGE_MANAGER = get_package_manager()
 
 
-@pytest.fixture
-def default_template(tmp_path):
-    env_name_id = f"pytest_{uuid.uuid4()}-env"
+@pytest.fixture(scope="function")
+def template_environment(tmp_path, request):
+    env_name = f"pytest_{uuid.uuid4()}-env"
     cookiecutter(
         template=TEMPLATE_DIRECTORY,
         output_dir=str(tmp_path),
         no_input=True,
-        extra_context={"env_name": env_name_id},
+        extra_context={"env_name": env_name, **request.param},
     )
-    yield tmp_path.joinpath("data-science-project")
-    PACKAGE_MANAGER.remove_env(env_name=env_name_id)
+    yield tmp_path.joinpath("data-science-project"), env_name, request.param
+    PACKAGE_MANAGER.remove_env(env_name=env_name)
 
 
-def test_default_template(default_template):
+def validate_base_project_files(env_dir):
+    """
+    Validates that the environment directory was created and contains the expected files
+    """
     expected_dirs = [".git/", "data/"]
     for expected_dir in expected_dirs:
-        expected_dir_path = default_template.joinpath(expected_dir)
+        expected_dir_path = env_dir.joinpath(expected_dir)
         assert expected_dir_path.is_dir(), f"Did not find dir: {expected_dir_path}"
+
     expected_files = [
         ".commitlintrc.yaml",
         ".gitattributes",
@@ -45,5 +50,43 @@ def test_default_template(default_template):
         "README.md",
     ]
     for expected_file in expected_files:
-        expected_file_path = default_template.joinpath(expected_file)
+        expected_file_path = env_dir.joinpath(expected_file)
         assert expected_file_path.is_file(), f"Did not find file: {expected_file_path}"
+
+
+def validate_gitlab_configuration(env_dir, expect_present=True):
+    file_path = env_dir.joinpath(".gitlab-ci.yml")
+    if expect_present:
+        assert file_path.is_file(), f"Did not find file: {file_path}"
+    else:
+        assert not file_path.is_file(), f"Expected not to find file: {file_path}"
+
+
+def validate_pre_commit(env_dir, env_name):
+    """
+    Runs pre-commit hooks in the created environment to ensure that all generated/templated files are compatible
+    :param env_dir:
+    :param env_name:
+    :return:
+    """
+    cwd = os.getcwd()
+    os.chdir(env_dir)
+    PACKAGE_MANAGER.run_subprocess_in_env(env_name, ["pre-commit", "run", "--all-files"])
+    os.chdir(cwd)
+
+
+@pytest.mark.parametrize(
+    "template_environment",
+    [
+        {},
+        {"cicd_configuration": "gitlab"},
+    ],
+    indirect=["template_environment"],
+)
+def test_template(template_environment):
+    env_dir, env_name, env_config = template_environment
+    validate_base_project_files(env_dir)
+    validate_gitlab_configuration(
+        env_dir, expect_present=env_config.get("cicd_configuration") == "gitlab"
+    )
+    validate_pre_commit(env_dir, env_name)


### PR DESCRIPTION
Parametrize the template initialization to allow for multiple test runs with different configurations. Add additional tests for CI/CD initialization and pre-commit checks.